### PR TITLE
[SETUP][#6] - add JaCoCo dependece in gradle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
 	java
 	id("org.springframework.boot") version "3.0.6"
 	id("io.spring.dependency-management") version "1.1.0"
+	id("jacoco")
 }
 
 group = "br.com.cinemenu"
@@ -32,6 +33,17 @@ dependencies {
 
 tasks.withType<Test> {
 	useJUnitPlatform()
+}
+jacoco {
+	toolVersion = "0.8.9"
+	reportsDir = file("$buildDir/customJacocoReportDir")
+}
+tasks.jacocoTestReport {
+	reports {
+		xml.isEnabled = false
+		csv.isEnabled = false
+		html.destination = file("${buildDir}/jacocoHtml")
+	}
 }
 
 apply(from = ".githooks/apply-git-hooks.gradle")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,13 +36,13 @@ tasks.withType<Test> {
 }
 jacoco {
 	toolVersion = "0.8.9"
-	reportsDir = file("$buildDir/customJacocoReportDir")
+	reportsDir = file("$buildDir/jacoco")
 }
 tasks.jacocoTestReport {
 	reports {
 		xml.isEnabled = false
 		csv.isEnabled = false
-		html.destination = file("${buildDir}/jacocoHtml")
+		html.destination = file("${buildDir}/jacoco/test/html")
 	}
 }
 


### PR DESCRIPTION
Add JaCoCo dependence to project. Thats a lib will work whit JUnit to create logs and coverage code in tests.

Fixes #6 