### PR TITLE
[FEATURE][#54] - Implements Endpoint lists fork and tests

### DIFF
--- a/src/main/java/br/com/cinemenu/cinemenuapi/domain/dto/responsedto/MediaListResponseDto.java
+++ b/src/main/java/br/com/cinemenu/cinemenuapi/domain/dto/responsedto/MediaListResponseDto.java
@@ -30,7 +30,7 @@ public record MediaListResponseDto(
 ) {
     public MediaListResponseDto(MediaList previewMediaList) {
         this(
-                previewMediaList.getId(), previewMediaList.getTitle(), previewMediaList.getDescription(), 0,
+                previewMediaList.getId(), previewMediaList.getTitle(), previewMediaList.getDescription(), previewMediaList.getUserMedias().size(),
                 previewMediaList.getVisibility(), previewMediaList.getAmountLike(), previewMediaList.getAmountCopy(),
                 previewMediaList.getUser().getId(), previewMediaList.getLastChange()
         );

--- a/src/main/java/br/com/cinemenu/cinemenuapi/domain/entity/MediaList.java
+++ b/src/main/java/br/com/cinemenu/cinemenuapi/domain/entity/MediaList.java
@@ -51,10 +51,24 @@ public class MediaList {
         this.user = user;
     }
 
+    public MediaList(MediaList mediaListReference, CineMenuUser user) {
+        this.title = mediaListReference.getTitle().trim();
+        this.description = mediaListReference.getDescription();
+        this.visibility = mediaListReference.getVisibility();
+        this.amountLike = 0;
+        this.amountCopy = 0;
+        this.createdAt = OffsetDateTime.now();
+        this.user = user;
+    }
+
     public void update(MediaListRequestDto requestDto) {
         if (requestDto.title() != null) this.title = requestDto.title();
         this.description = requestDto.description();
         if (requestDto.visibility() != null) this.visibility = requestDto.visibility();
         this.lastChange = OffsetDateTime.now();
+    }
+
+    public void incrementCopyCounter() {
+        this.amountCopy = this.amountCopy + 1;
     }
 }

--- a/src/main/java/br/com/cinemenu/cinemenuapi/domain/entity/UserMedia.java
+++ b/src/main/java/br/com/cinemenu/cinemenuapi/domain/entity/UserMedia.java
@@ -40,6 +40,14 @@ public class UserMedia {
         this.watched = requestDto.watched();
     }
 
+    public UserMedia(UserMedia userMedia) {
+        this.idTmdb = userMedia.getIdTmdb();
+        this.mediaType = userMedia.getMediaType();
+        this.note = "";
+        this.userRating = 0.0;
+        this.watched = false;
+    }
+
     public void update(UserMediaUpdateMethodRequestDto updateMethodRequestDto) {
         if (updateMethodRequestDto.note() != null) this.note = updateMethodRequestDto.note();
         if (updateMethodRequestDto.userRating() != null) this.userRating = updateMethodRequestDto.userRating();

--- a/src/main/java/br/com/cinemenu/cinemenuapi/rest/controller/MediaListController.java
+++ b/src/main/java/br/com/cinemenu/cinemenuapi/rest/controller/MediaListController.java
@@ -5,6 +5,7 @@ import br.com.cinemenu.cinemenuapi.domain.dto.requestdto.UserMediaRequestDto;
 import br.com.cinemenu.cinemenuapi.domain.dto.requestdto.UserMediaUpdateMethodRequestDto;
 import br.com.cinemenu.cinemenuapi.domain.dto.responsedto.MediaListResponseDto;
 import br.com.cinemenu.cinemenuapi.domain.dto.responsedto.UserMediaResponseDto;
+import br.com.cinemenu.cinemenuapi.domain.entity.MediaList;
 import br.com.cinemenu.cinemenuapi.domain.entity.user.CineMenuUser;
 import br.com.cinemenu.cinemenuapi.domain.repository.UserRepository;
 import br.com.cinemenu.cinemenuapi.infra.security.AuthenticationFacade;
@@ -20,6 +21,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.net.URI;
 import java.util.List;
 
 @RestController
@@ -40,6 +42,11 @@ public class MediaListController {
     @PostMapping("/user_media")
     public ResponseEntity<List<UserMediaResponseDto>> createNewUserMedia(@RequestParam(name = "id_list") String mediaListId, @RequestBody @Valid UserMediaRequestDto requestDtoList) {
         return ResponseEntity.status(HttpStatus.CREATED).body(userMediaService.createNewUserMediaAndAddToMediaList(getUser(), mediaListId, requestDtoList));
+    }
+
+    @PostMapping("/fork")
+    public ResponseEntity<MediaListResponseDto> copyListById(@RequestParam("id") String id) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(mediaListService.copyListById(getUser(), id));
     }
 
     @GetMapping

--- a/src/main/java/br/com/cinemenu/cinemenuapi/rest/service/MediaListService.java
+++ b/src/main/java/br/com/cinemenu/cinemenuapi/rest/service/MediaListService.java
@@ -2,10 +2,12 @@ package br.com.cinemenu.cinemenuapi.rest.service;
 
 import br.com.cinemenu.cinemenuapi.domain.dto.requestdto.MediaListRequestDto;
 import br.com.cinemenu.cinemenuapi.domain.dto.responsedto.MediaListResponseDto;
+import br.com.cinemenu.cinemenuapi.domain.entity.UserMedia;
 import br.com.cinemenu.cinemenuapi.domain.entity.user.CineMenuUser;
 import br.com.cinemenu.cinemenuapi.domain.entity.MediaList;
 import br.com.cinemenu.cinemenuapi.domain.enumeration.ListVisibility;
 import br.com.cinemenu.cinemenuapi.domain.repository.MediaListRepository;
+import br.com.cinemenu.cinemenuapi.domain.repository.UserRepository;
 import br.com.cinemenu.cinemenuapi.infra.exceptionhandler.exception.CineMenuEntityNotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
@@ -20,7 +22,8 @@ import java.util.List;
 @AllArgsConstructor
 public class MediaListService {
 
-    private final MediaListRepository repository;
+    private final MediaListRepository mediaListRepository;
+    private final UserRepository userRepository;
 
     private static final String LIST_NOT_FOUND_WHIT_USER = "List whit id: %s not found for user: %s";
     private static final String LIST_NOT_FOUND_BY_QUERY = "List not found for query: %s";
@@ -30,7 +33,7 @@ public class MediaListService {
     @Transactional
     public MediaListResponseDto create(CineMenuUser user, MediaListRequestDto requestDto) {
         MediaList newPreviewMediaList = new MediaList(requestDto, user);
-        repository.save(newPreviewMediaList);
+        mediaListRepository.save(newPreviewMediaList);
         user.getMediaLists().add(newPreviewMediaList);
         return new MediaListResponseDto(newPreviewMediaList);
     }
@@ -44,7 +47,7 @@ public class MediaListService {
     }
 
     public MediaListResponseDto getListById(CineMenuUser user, String listId) {
-        var previewMediaList = repository.findById(listId).orElseThrow(() -> new CineMenuEntityNotFoundException(LIST_NOT_FOUND.formatted(listId)));
+        var previewMediaList = mediaListRepository.findById(listId).orElseThrow(() -> new CineMenuEntityNotFoundException(LIST_NOT_FOUND.formatted(listId)));
 
         if (user.getMediaLists().contains(previewMediaList) || ListVisibility.PUBLIC.equals(previewMediaList.getVisibility()))
             return new MediaListResponseDto(previewMediaList);
@@ -55,7 +58,7 @@ public class MediaListService {
     public Page<MediaListResponseDto> getUserMediaListsBySearch(CineMenuUser user, String query, Pageable page) {
         String sanitizedQuery = query.trim();
 
-        List<MediaList> queryResults = repository.findAllByTitleLikeIgnoreCase("%" + sanitizedQuery + "%");
+        List<MediaList> queryResults = mediaListRepository.findAllByTitleLikeIgnoreCase("%" + sanitizedQuery + "%");
 
         var pageList = queryResults.stream()
                 .filter(mediaList -> user.getMediaLists().contains(mediaList))
@@ -69,7 +72,7 @@ public class MediaListService {
     public Page<MediaListResponseDto> getPublicMediaListsBySearch(String query, Pageable page) {
         String sanitizedQuery = query.trim();
 
-        List<MediaList> queryResults = repository.findAllByTitleLikeIgnoreCase("%" + sanitizedQuery + "%");
+        List<MediaList> queryResults = mediaListRepository.findAllByTitleLikeIgnoreCase("%" + sanitizedQuery + "%");
         if (queryResults.isEmpty()) throw new CineMenuEntityNotFoundException(PUBLIC_LIST_NOT_FOUND_BY_QUERY.formatted(query));
 
         var pageList = queryResults.stream()
@@ -83,26 +86,42 @@ public class MediaListService {
 
     @Transactional
     public MediaListResponseDto editById(CineMenuUser user, String listId, MediaListRequestDto requestDto) {
-        MediaList mediaList = repository.findById(listId).orElseThrow(() -> new CineMenuEntityNotFoundException(LIST_NOT_FOUND_WHIT_USER.formatted(listId, user.getUsername())));
+        MediaList mediaList = mediaListRepository.findById(listId).orElseThrow(() -> new CineMenuEntityNotFoundException(LIST_NOT_FOUND_WHIT_USER.formatted(listId, user.getUsername())));
 
         if (!user.getMediaLists().contains(mediaList))
             throw new CineMenuEntityNotFoundException(LIST_NOT_FOUND_WHIT_USER.formatted(listId, user.getUsername()));
 
         mediaList.update(requestDto);
-        repository.save(mediaList);
+        mediaListRepository.save(mediaList);
         return new MediaListResponseDto(mediaList);
     }
 
     @Transactional
     public void deleteById(CineMenuUser user, String listId) {
-        MediaList mediaList = repository.findById(listId).orElseThrow(() -> new CineMenuEntityNotFoundException(LIST_NOT_FOUND_WHIT_USER.formatted(listId, user.getUsername())));
+        MediaList mediaList = mediaListRepository.findById(listId).orElseThrow(() -> new CineMenuEntityNotFoundException(LIST_NOT_FOUND_WHIT_USER.formatted(listId, user.getUsername())));
 
         if (!user.getMediaLists().contains(mediaList))
             throw new CineMenuEntityNotFoundException(LIST_NOT_FOUND_WHIT_USER.formatted(listId, user.getUsername()));
 
         user.getMediaLists().remove(mediaList);
 
-        repository.delete(mediaList);
+        mediaListRepository.delete(mediaList);
+    }
+
+    @Transactional
+    public MediaListResponseDto copyListById(CineMenuUser user, String id) {
+        MediaList mediaListReference = mediaListRepository.findById(id).orElseThrow(() -> new CineMenuEntityNotFoundException(LIST_NOT_FOUND.formatted(id)));
+        mediaListReference.incrementCopyCounter();
+        mediaListRepository.save(mediaListReference);
+
+        MediaList newMediaListByReference = new MediaList(mediaListReference, user);
+        List<UserMedia> rebuildUserMediaList = mediaListReference.getUserMedias().stream().map(UserMedia::new).toList();
+
+        newMediaListByReference.getUserMedias().addAll(rebuildUserMediaList);
+        user.getMediaLists().add(newMediaListByReference);
+        userRepository.save(user);
+
+        return new MediaListResponseDto(newMediaListByReference);
     }
 
     private Page<MediaListResponseDto> buildPage(List<MediaListResponseDto> list, Pageable page) {

--- a/src/test/java/br/com/cinemenu/cinemenuapi/rest/controller/MediaListControllerTest.java
+++ b/src/test/java/br/com/cinemenu/cinemenuapi/rest/controller/MediaListControllerTest.java
@@ -230,4 +230,17 @@ class MediaListControllerTest {
         // Then
         assertEquals(HttpStatus.NO_CONTENT, controllerResponse.getStatusCode());
     }
+
+    @Test
+    @DisplayName("Test copyListById() method expecting HttpStatus 201 CREATED")
+    void testCopyListByIdScene01() {
+        // Given
+        String validListId = mediaList.getId();
+
+        // When
+        ResponseEntity<MediaListResponseDto> controllerResponse = controller.copyListById(validListId);
+
+        // Then
+        assertEquals(HttpStatus.CREATED, controllerResponse.getStatusCode());
+    }
 }


### PR DESCRIPTION
Implements endpoint to copy existent list by id.

## Exemple of use:

`POST: lists/fork?id=<StringUUID>`

Expected response:
```json
{
    "title": "TestFork01",
    "description": "list builded for test",
    "visibility": "PUBLIC",
    "total_elements": 2,
    "amount_like": 0,
    "amount_copy": 0,
    "owner_id": "82332433-3f2c-47cb-adab-998b33002313"
}
```

For each user media in the list is made a new media whit new id and only TMDB_id and MediaType remains from the list used by reference to fork.

Fixes #54 