### PR TITLE
[FEATURE][#64] - Create endpoint to return all public lists from user id

### DIFF
--- a/src/main/java/br/com/cinemenu/cinemenuapi/domain/repository/MediaListRepository.java
+++ b/src/main/java/br/com/cinemenu/cinemenuapi/domain/repository/MediaListRepository.java
@@ -1,10 +1,16 @@
 package br.com.cinemenu.cinemenuapi.domain.repository;
 
 import br.com.cinemenu.cinemenuapi.domain.entity.MediaList;
+import br.com.cinemenu.cinemenuapi.domain.entity.user.CineMenuUser;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface MediaListRepository extends JpaRepository<MediaList, String> {
     List<MediaList> findAllByTitleLikeIgnoreCase(String query);
+
+    @Query(value = "SELECT m FROM MediaList m WHERE m.visibility = 'PUBLIC' AND m.user = :user")
+    List<MediaList> getAllPublicListsFromUser(@Param("user") CineMenuUser user);
 }

--- a/src/main/java/br/com/cinemenu/cinemenuapi/rest/controller/MediaListController.java
+++ b/src/main/java/br/com/cinemenu/cinemenuapi/rest/controller/MediaListController.java
@@ -188,6 +188,28 @@ public class MediaListController {
         return ResponseEntity.ok(mediaListService.getPublicMediaListsBySearch(query, page));
     }
 
+    @GetMapping("/user")
+    @Operation(
+            summary = "Return all public media lists from user ID.",
+            description = """
+                    Get all media lists whit public visibility from the provided user ID.
+                    By default, the initial index of the page is based on 0 (zero).
+                    Its possible use parameters like size, and sort.
+                    """,
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Successfully return.")
+            },
+            parameters = {
+                    @Parameter(name = "user_id", description = "ID of an existing user", required = true),
+                    @Parameter(name = "page", description = "Page number.", required = true),
+                    @Parameter(name = "sort", description = "Change the sort criterion.", required = false),
+                    @Parameter(name = "size", description = "Change the number of elements for page.", required = false)
+            }
+    )
+    public ResponseEntity<Page<MediaListResponseDto>> getPublicListsByUserId(@RequestParam("user_id") String userId, Pageable pageable) {
+        return ResponseEntity.ok(mediaListService.getPublicListsPageByUserId(userId, pageable));
+    }
+
     @PutMapping
     @Operation(
             summary = "Edit a list by ID.",

--- a/src/main/java/br/com/cinemenu/cinemenuapi/rest/service/MediaListService.java
+++ b/src/main/java/br/com/cinemenu/cinemenuapi/rest/service/MediaListService.java
@@ -128,9 +128,7 @@ public class MediaListService {
     public Page<MediaListResponseDto> getPublicListsPageByUserId(String userId, Pageable pageable) {
         CineMenuUser user = userRepository.findById(userId).orElseThrow(() -> new CineMenuEntityNotFoundException(USER_NOT_FOUND));
 
-        List<MediaListResponseDto> responseList = user.getMediaLists().stream()
-                .filter(mediaList -> mediaList.getVisibility().equals(ListVisibility.PUBLIC))
-                .map(MediaListResponseDto::new).toList();
+        List<MediaListResponseDto> responseList = mediaListRepository.getAllPublicListsFromUser(user).stream().map(MediaListResponseDto::new).toList();
 
         return buildPage(responseList, pageable);
     }

--- a/src/main/java/br/com/cinemenu/cinemenuapi/rest/service/MediaListService.java
+++ b/src/main/java/br/com/cinemenu/cinemenuapi/rest/service/MediaListService.java
@@ -29,6 +29,7 @@ public class MediaListService {
     private static final String LIST_NOT_FOUND_BY_QUERY = "List not found for query: %s";
     private static final String PUBLIC_LIST_NOT_FOUND_BY_QUERY = "Public lists not found for query: %s";
     private static final String LIST_NOT_FOUND = "List whit id: %s not found";
+    private static final String USER_NOT_FOUND = "User whit id: %s not found";
 
     @Transactional
     public MediaListResponseDto create(CineMenuUser user, MediaListRequestDto requestDto) {
@@ -122,6 +123,16 @@ public class MediaListService {
         userRepository.save(user);
 
         return new MediaListResponseDto(newMediaListByReference);
+    }
+
+    public Page<MediaListResponseDto> getPublicListsPageByUserId(String userId, Pageable pageable) {
+        CineMenuUser user = userRepository.findById(userId).orElseThrow(() -> new CineMenuEntityNotFoundException(USER_NOT_FOUND));
+
+        List<MediaListResponseDto> responseList = user.getMediaLists().stream()
+                .filter(mediaList -> mediaList.getVisibility().equals(ListVisibility.PUBLIC))
+                .map(MediaListResponseDto::new).toList();
+
+        return buildPage(responseList, pageable);
     }
 
     private Page<MediaListResponseDto> buildPage(List<MediaListResponseDto> list, Pageable page) {

--- a/src/test/java/br/com/cinemenu/cinemenuapi/CineMenuApiApplicationTest.java
+++ b/src/test/java/br/com/cinemenu/cinemenuapi/CineMenuApiApplicationTest.java
@@ -5,6 +5,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class CineMenuApiApplicationTest {
+
     @Test
     void testMainClass() {
         CineMenuApiApplication.main(new String[] {});

--- a/src/test/java/br/com/cinemenu/cinemenuapi/rest/controller/MediaListControllerTest.java
+++ b/src/test/java/br/com/cinemenu/cinemenuapi/rest/controller/MediaListControllerTest.java
@@ -244,4 +244,17 @@ class MediaListControllerTest {
         // Then
         assertEquals(HttpStatus.CREATED, controllerResponse.getStatusCode());
     }
+
+    @Test
+    @DisplayName("Test getPublicListsByUserId() method whit valid user id")
+    void testGetPublicListsByUserId() {
+        // Given
+        String validUserId = user.getId();
+
+        // When
+        ResponseEntity<Page<MediaListResponseDto>> controllerResponse = controller.getPublicListsByUserId(validUserId, page);
+
+        // Then
+        assertEquals(HttpStatus.OK, controllerResponse.getStatusCode());
+    }
 }

--- a/src/test/java/br/com/cinemenu/cinemenuapi/rest/service/MediaListServiceTest.java
+++ b/src/test/java/br/com/cinemenu/cinemenuapi/rest/service/MediaListServiceTest.java
@@ -412,6 +412,7 @@ class MediaListServiceTest {
         user.getMediaLists().add(publicMediaList);
         user.getMediaLists().add(privateMediaList);
         when(userRepository.findById(validUserId)).thenReturn(Optional.ofNullable(user));
+        when(mediaListRepository.getAllPublicListsFromUser(user)).thenReturn(List.of(publicMediaList));
 
         // When
         Page<MediaListResponseDto> serviceResponse = service.getPublicListsPageByUserId(validUserId, page);

--- a/src/test/java/br/com/cinemenu/cinemenuapi/rest/service/MediaListServiceTest.java
+++ b/src/test/java/br/com/cinemenu/cinemenuapi/rest/service/MediaListServiceTest.java
@@ -403,4 +403,33 @@ class MediaListServiceTest {
             service.copyListById(user, invalidId);
         });
     }
+
+    @Test
+    @DisplayName("Test getPublicListsPageByUserId() method whit valid user ID and page")
+    void testGetPublicListsPageByUserIdScene01() {
+        // Given
+        String validUserId = user.getId();
+        user.getMediaLists().add(publicMediaList);
+        user.getMediaLists().add(privateMediaList);
+        when(userRepository.findById(validUserId)).thenReturn(Optional.ofNullable(user));
+
+        // When
+        Page<MediaListResponseDto> serviceResponse = service.getPublicListsPageByUserId(validUserId, page);
+
+        // Then
+        assertEquals(1, serviceResponse.getContent().size());
+        verify(userRepository).findById(validUserId);
+    }
+
+    @Test
+    @DisplayName("Test getPublicListsPageByUserId() method whit invalid user ID")
+    void testGetPublicListsPageByUserIdScene02() {
+        // Given
+        String invalidUserId = "invalidID";
+
+        // When // Then
+        assertThrows(CineMenuEntityNotFoundException.class, () -> {
+            service.getPublicListsPageByUserId(invalidUserId, page);
+        });
+    }
 }


### PR DESCRIPTION
Create endpoint to return a page of all public lists from provided user ID.

Exemple of use: `GET: lists/user?user_id=<StringUUID>`

Return:
```json
{
  "content": [
    {
      "id": "47a7ba1f-a21c-4942-9fd5-b8dec6ed92cf",
      "title": "Test list",
      "description": "test list",
      "visibility": "PUBLIC",
      "total_elements": 0,
      "amount_like": 0,
      "amount_copy": 0,
      "owner_id": "2a157fa8-f211-471d-98bc-075ddf54256d"
    },
    {
      "id": "84da1dfd-aa07-4509-ad3d-05bd34fcb5b6",
      "title": "Test list",
      "description": "test list",
      "visibility": "PUBLIC",
      "total_elements": 0,
      "amount_like": 0,
      "amount_copy": 0,
      "owner_id": "2a157fa8-f211-471d-98bc-075ddf54256d"
    }
  ],
  "pageable": {
    "sort": {
      "empty": true,
      "sorted": false,
      "unsorted": true
    },
    "offset": 0,
    "pageNumber": 0,
    "pageSize": 20,
    "paged": true,
    "unpaged": false
  },
  "totalPages": 1,
  "totalElements": 2,
  "last": true,
  "size": 20,
  "number": 0,
  "sort": {
    "empty": true,
    "sorted": false,
    "unsorted": true
  },
  "numberOfElements": 2,
  "first": true,
  "empty": false
}
```

Fixes #64 